### PR TITLE
Handle 433 mhz devices in Python

### DIFF
--- a/util.py
+++ b/util.py
@@ -1,6 +1,7 @@
 import datetime
 from typing import Tuple, Union
 import json
+import os
 
 def get_hour_minute(time: str) -> Tuple[str, str]:
     return [int(x) for x in time.split(":")]
@@ -15,3 +16,6 @@ def time_in_range(start: datetime.time, end: datetime.time, time: datetime.time)
 def load_json_file(filename: str) -> Union[dict, list]:
     with open(filename) as file:
         return json.load(file)
+
+def is_debug() -> bool:
+    return os.environ.get("DEBUG") is not None


### PR DESCRIPTION
Previously, a dedicated Arduino was used for this. Managing this in Python allows for less complexity and faster code iteration if needed.